### PR TITLE
Work around a potential bug in pw(8) when '-m' is specified.

### DIFF
--- a/release/tools/arm.subr
+++ b/release/tools/arm.subr
@@ -82,7 +82,7 @@ arm_create_user() {
 	# and set the default password for the 'root' user to 'root'.
 	chroot ${CHROOTDIR} /usr/sbin/pw -R ${DESTDIR} \
 		groupadd freebsd -g 1001
-	chroot ${CHROOTDIR} mkdir -p ${DESTDIR}/home
+	chroot ${CHROOTDIR} mkdir -p ${DESTDIR}/home/freebsd
 	chroot ${CHROOTDIR} /usr/sbin/pw -R ${DESTDIR} \
 		useradd freebsd \
 		-m -M 0755 -w yes -n freebsd -u 1001 -g 1001 -G 0 \


### PR DESCRIPTION
According to the manual page, '-m' should create the user home
directory, however rigorous testing suggests it does not, and
it is unclear if this is an implementation or expectation issue.

Sponsored by:	The FreeBSD Foundation